### PR TITLE
Add support for 'mov' video format

### DIFF
--- a/nbrowser
+++ b/nbrowser
@@ -268,7 +268,7 @@ url_handler(){
 		nbrowser_dbang "$cleanurl"
 	else
 		case "$cleanurl" in
-			**ted.com/**|*youtube.com/watch*|*youtube.com/playlist*|*youtu.be*|*//www.twitch.tv/*|*//twitch.tv/*|*.mp4|*.mkv|*.webm|*.mp3|*.flac|*.opus|*mp3?source*|*gifv|*.m3u|*.m3u8)
+			**ted.com/**|*youtube.com/watch*|*youtube.com/playlist*|*youtu.be*|*//www.twitch.tv/*|*//twitch.tv/*|*.mp4|*.mkv|*.webm|*.mp3|*.flac|*.opus|*mp3?source*|*gifv|*.m3u|*.m3u8|*.mov)
 				open_video_with "$cleanurl"
 				;;
 			*png|*jpg|*jpe|*jpeg|*gif|*.jpg\?r=*)


### PR DESCRIPTION
Hi,
I hope all is going well. I noticed that `*.mov` videos get opened in the browser instead of the video player.

Example: https://user-images.githubusercontent.com/80150109/170867699-9ff15056-e34e-47ca-b86a-77386c08f671.mov

