### PR TITLE
dev

### DIFF
--- a/nbrowser
+++ b/nbrowser
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# nbrowser v0.8
+# nbrowser v0.8.1
 # Requires bash 4+
 # author : odnar-dev <https://github.com/odnar-dev>
 # source : https://github.com/MyOS-ArchLinux/nbrowser
@@ -85,7 +85,7 @@ browser_count=1
 
 # use: add_browser( browser_id, browser_name, browser_path, browser_args )
 add_browser(){
-	browser_count=$((browser_count+1))
+	[ -z "${5}" ] && browser_count=$((browser_count+1))
 	local _browser_id="${1}"
 	BROWSER_LIST[${5:-$browser_count}]=${_browser_id}
 	BROWSER_NAME[${_browser_id}]="${2:-$_browser_id}"

--- a/nbrowser
+++ b/nbrowser
@@ -94,7 +94,7 @@ add_browser(){
 }
 
 # use: rm_browser(browse_id, browser_id...)
-rm_browser(){
+rm_browsers(){
 	local _browsers_to_rm=($@)
 	local _browser_id
 	declare -A REMOVE_LIST
@@ -108,7 +108,7 @@ rm_browser(){
 	BROWSER_LIST=("${BROWSER_LIST[@]}")
 }
 
-list_browsers(){
+ls_browsers(){
 	local _browser_id
 	for _browser_id in "${BROWSER_LIST[@]}" ; do
 		[ -z "${BROWSER_NAME[${_browser_id}]}" ] && continue
@@ -116,7 +116,8 @@ list_browsers(){
 	done | awk '!a[$0]++' | awk 'BEGIN { RS="\n"; FS="	:	" } { print $1 "\t : " $2 }'| column -t -s $'\t'
 }
 
-list_browsers_table(){
+ls_browsers_table(){
+	add_browser "id" "browser name" "browser path" "browser args" "0"
 	local _browser_id
 	for _browser_id in "${BROWSER_LIST[@]}" ; do
 		[ -z "${BROWSER_NAME[${_browser_id}]}" ] && continue
@@ -125,14 +126,14 @@ list_browsers_table(){
 }
 
 ## firefox based browser
-for prog in ${FIREFOX_BASED_BROWSERS[*]}; do
+for prog in "${FIREFOX_BASED_BROWSERS[@]}"; do
 	if has "${prog,,}" ; then
 		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
 		add_browser "${prog,,}_prv" "${prog} [Private]" "$(command -v ${prog,,})" "--private-window"
 	fi
 done
 ## chromium based browser
-for prog in ${CHROMIUM_BASED_BROWSERS[*]}; do
+for prog in "${CHROMIUM_BASED_BROWSERS[@]}"; do
 	if has "${prog,,}" ; then
 		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
 		add_browser "${prog,,}_prv" "${prog} [Private]" "$(command -v ${prog,,})" "--incognito"
@@ -140,7 +141,7 @@ for prog in ${CHROMIUM_BASED_BROWSERS[*]}; do
 done
 
 ## other browsers
-for prog in ${OTHER_BASED_BROWSERS[*]} ; do
+for prog in "${OTHER_BASED_BROWSERS[@]}" ; do
 	if has "${prog,,}" ; then
 		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
 	fi
@@ -185,7 +186,7 @@ if ! has _copy_to_clipboard ;then
 fi
 
 open_a_browser(){
-	selected_browser=$(list_browsers | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "${#BROWSER_NAME[@]}")
+	selected_browser=$(ls_browsers | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "${#BROWSER_NAME[@]}")
 
 	[ -z "${selected_browser}" ] && exit 0
 
@@ -274,7 +275,7 @@ open_in_browser(){
 			current_win_pid=$(xdotool getwindowpid "$current_win_id" )
 			current_win_name=$(ps -o comm= -p "$current_win_pid" || xdotool getwindowname "$current_win_id" )
 		fi
-#		current_browser=$(list_browsers | awk -v current_win_name="${current_win_name:-}" 'BEGIN { RS="\n"; } $1 ~ current_win_name {p=1; exit} END {if(p) print $1}')
+#		current_browser=$(ls_browsers | awk -v current_win_name="${current_win_name:-}" 'BEGIN { RS="\n"; } $1 ~ current_win_name {p=1; exit} END {if(p) print $1}')
 #		notify-send "current_browser: $current_browser"
 		[ ! -z "${current_win_name}" ] && BROWSER_LIST[1]="${current_win_name}"
 	fi
@@ -284,7 +285,7 @@ open_in_browser(){
 		COPY_TO_CLIPBOARD_OPTION=false
 	fi
 
-	selected_browser=$(list_browsers | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "${#BROWSER_NAME[@]}" )
+	selected_browser=$(ls_browsers | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "${#BROWSER_NAME[@]}" )
 
 	[ -z "${selected_browser}" ] && exit 0
 
@@ -479,7 +480,7 @@ main(){
 
 case "${@}" in
 	--ls-browsers|-lsb)
-		list_browsers_table
+		ls_browsers_table
 		exit
 		;;
 esac

--- a/nbrowser
+++ b/nbrowser
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# nbrowser v0.8.1
+# nbrowser v0.9
 # Requires bash 4+
 # author : odnar-dev <https://github.com/odnar-dev>
 # source : https://github.com/MyOS-ArchLinux/nbrowser

--- a/nbrowser
+++ b/nbrowser
@@ -14,6 +14,10 @@ NBROWSER_SIMPLE_URL_HANDLER=${NBROWSER_SIMPLE_URL_HANDLER:-false}
 
 declare -A ENGINES
 
+declare -A BROWSER_NAME
+declare -A BROWSER_PATH
+declare -A BROWSER_ARGS
+
 ENGINES=(
 	["google"]="https://www.google.com/search?q="
 	["g"]="https://www.google.com/search?q="
@@ -33,9 +37,9 @@ ENGINES=(
 	["ytb"]="https://www.youtube.com/results?search_query="
 )
 
-FIREFOX_BASED_BROWSERS=(librewolf firefox floorp icecat palemoon firedragon)
-CHROMIUM_BASED_BROWSERS=(google-chrome-stable chromium brave vivaldi-stable opera)
-OTHER_BASED_BROWSERS=(badwolf qutebrowser ephemeral)
+FIREFOX_BASED_BROWSERS=(LibreWolf FireFox Floorp IceCat Palemoon FireDragon)
+CHROMIUM_BASED_BROWSERS=(google-chrome-stable Chromium Brave Vivaldi-stable Opera)
+OTHER_BASED_BROWSERS=(BadWolf qutebrowser Ephemeral)
 
 has() {
 	case "$(command -v "$1" 2>/dev/null)" in
@@ -79,34 +83,42 @@ fi
 ## keep the first place to special action
 browser_count=1
 
+# use: add_browser( browser_id, browser_name, browser_path, browser_args )
 add_browser(){
-	local browser_name="${1:?}"
-	local browser_path="${2:?}"
 	browser_count=$((browser_count+1))
-	installed_browsers[$browser_count]="${browser_name:?}	:	${browser_path:?}"
+	local _browser_id="${1}"
+	BROWSER_LIST[${5:-$browser_count}]=${_browser_id}
+	BROWSER_NAME[${_browser_id}]="${2:-$_browser_id}"
+	BROWSER_PATH[${_browser_id}]="${3:-$(command -v $_browser_id )}"
+	BROWSER_ARGS[${_browser_id}]="${4:-}"
+}
+
+list_browsers(){
+	for _browser_id in "${BROWSER_LIST[@]}" ; do
+		[ -z "${BROWSER_NAME[${_browser_id}]}" ] && continue
+		echo "${BROWSER_NAME[${_browser_id}]}	:	${BROWSER_PATH[${_browser_id}]} ${BROWSER_ARGS[${_browser_id}]}"
+	done | awk '!a[$0]++' | awk 'BEGIN { RS="\n"; FS="	:	" } { print $1 "\t : " $2 }'| column -t -s $'\t'
 }
 
 ## firefox based browser
 for prog in ${FIREFOX_BASED_BROWSERS[*]}; do
-	if has "$prog" ; then
-		add_browser "$prog" "$(command -v $prog)"
-		add_browser "$prog [Private]" "$(command -v $prog) --private-window"
+	if has "${prog,,}" ; then
+		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
+		add_browser "${prog,,}_prv" "${prog} [Private]" "$(command -v ${prog,,})" "--private-window"
 	fi
 done
-
 ## chromium based browser
 for prog in ${CHROMIUM_BASED_BROWSERS[*]}; do
-	if has "$prog" ; then
-		add_browser "$prog" "$(command -v $prog)"
-		# add private window
-		add_browser "$prog [Private]" "$(command -v $prog) --incognito"
+	if has "${prog,,}" ; then
+		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
+		add_browser "${prog,,}_prv" "${prog} [Private]" "$(command -v ${prog,,})" "--incognito"
 	fi
 done
 
 ## other browsers
 for prog in ${OTHER_BASED_BROWSERS[*]} ; do
-	if has "$prog" ; then
-		add_browser "$prog" "$(command -v $prog)"
+	if has "${prog,,}" ; then
+		add_browser "${prog,,}" "${prog}" "$(command -v ${prog,,})"
 	fi
 done
 
@@ -149,7 +161,7 @@ if ! has _copy_to_clipboard ;then
 fi
 
 open_a_browser(){
-	selected_browser=$(printf "%s\n" "${installed_browsers[@]}" | awk '!a[$0]++' | awk 'BEGIN { RS="\n"; FS="	:	" } { print $1 "\t : " $2 }'| column -t -s $'\t' | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "$((browser_count-1))")
+	selected_browser=$(list_browsers | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "$((browser_count-1))")
 
 	[ -z "${selected_browser}" ] && exit 0
 
@@ -238,17 +250,17 @@ open_in_browser(){
 			current_win_pid=$(xdotool getwindowpid "$current_win_id" )
 			current_win_name=$(ps -o comm= -p "$current_win_pid" || xdotool getwindowname "$current_win_id" )
 		fi
-		current_browser=$(printf "%s\n" "${installed_browsers[@]}" | awk -v current_win_name="${current_win_name:-}" 'BEGIN { RS="\n"; FS="	:	" } $1 ~ current_win_name {p=1; exit} END {if(p) print $1 "\t:\t" $2 }')
-		[ ! -z "${current_browser}" ] && installed_browsers[0]="${current_browser:-}"
+#		current_browser=$(list_browsers | awk -v current_win_name="${current_win_name:-}" 'BEGIN { RS="\n"; } $1 ~ current_win_name {p=1; exit} END {if(p) print $1}')
+#		notify-send "current_browser: $current_browser"
+		[ ! -z "${current_win_name}" ] && BROWSER_LIST[1]="${current_win_name}"
 	fi
 	# add clipboard
 	if [ "${COPY_TO_CLIPBOARD_OPTION}" = true ]; then
-		browser_count=$((browser_count+1))
-		installed_browsers[$browser_count]="Copy to clipboard"
+		add_browser "copy_to_clipboard" "Copy to clipboard" " " " " ""
 		COPY_TO_CLIPBOARD_OPTION=false
 	fi
 
-	selected_browser=$(printf "%s\n" "${installed_browsers[@]}" | awk '!a[$0]++' | awk 'BEGIN { RS="\n"; FS="	:	" } { print $1 "\t : " $2 }'| column -t -s $'\t' | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "$((browser_count-1))" )
+	selected_browser=$(list_browsers | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "$((browser_count-1))" )
 
 	[ -z "${selected_browser}" ] && exit 0
 
@@ -316,10 +328,10 @@ main(){
 	if [[ -e "${arg}" ]]; then
 		case "${arg}" in
 			*.pdf)
-				[ -z "${NBROWSER_PDF_VIEWER}" ]	|| installed_browsers[0]="PDF Reader	:	${NBROWSER_PDF_VIEWER}"
+				[ -z "${NBROWSER_PDF_VIEWER}" ]	|| add_browser "pdf_reader" "PDF Reader" "${NBROWSER_PDF_VIEWER}" "${NBROWSER_PDF_VIEWER_ARGS:-}" "0"
 				;;
 			*)
-				[ -z "${NBROWSER_HTML_EDITOR}" ] || installed_browsers[0]="Text Editor	:	${NBROWSER_HTML_EDITOR}"
+				[ -z "${NBROWSER_HTML_EDITOR}" ]	|| add_browser "text_editor" "Text Editor" "${NBROWSER_HTML_EDITOR}" "${NBROWSER_HTML_EDITOR_ARGS:-}" "0"
 				;;
 		esac
 		open_in_browser "$*"

--- a/nbrowser
+++ b/nbrowser
@@ -289,7 +289,7 @@ open_in_browser(){
 				nbrowser_ubang "$*"
 			fi
 			;;
-		"Copy to clipboard"*": ")
+		"Copy to clipboard"*":"*)
 			_copy_to_clipboard "$*"
 			;;
 		*)

--- a/nbrowser
+++ b/nbrowser
@@ -93,6 +93,21 @@ add_browser(){
 	BROWSER_ARGS[${_browser_id}]="${4:-}"
 }
 
+# use: rm_browser(browse_id, browser_id...)
+rm_browser(){
+	local _browsers_to_rm=($@)
+	local _browser_id
+	declare -A REMOVE_LIST
+	for _browser_id in "${_browsers_to_rm[@]}" ; do REMOVE_LIST[$_browser_id]=1 ; done
+	for k in "${!BROWSER_LIST[@]}" ; do
+		if [ "${REMOVE_LIST[${BROWSER_LIST[$k]}]-}" ] ; then
+			unset "BROWSER_NAME[${BROWSER_LIST[$k]}]" ; unset "BROWSER_PATH[${BROWSER_LIST[$k]}]"
+			unset "BROWSER_ARGS[${BROWSER_LIST[$k]}]" ; unset 'BROWSER_LIST[k]'
+		fi
+	done
+	BROWSER_LIST=("${BROWSER_LIST[@]}")
+}
+
 list_browsers(){
 	local _browser_id
 	for _browser_id in "${BROWSER_LIST[@]}" ; do

--- a/nbrowser
+++ b/nbrowser
@@ -38,7 +38,7 @@ ENGINES=(
 )
 
 FIREFOX_BASED_BROWSERS=(LibreWolf FireFox Floorp IceCat Palemoon FireDragon)
-CHROMIUM_BASED_BROWSERS=(google-chrome-stable Chromium Brave Vivaldi-stable Opera)
+CHROMIUM_BASED_BROWSERS=(google-chrome-stable Chromium Brave Vivaldi-Stable Opera)
 OTHER_BASED_BROWSERS=(BadWolf qutebrowser Ephemeral)
 
 has() {
@@ -94,10 +94,19 @@ add_browser(){
 }
 
 list_browsers(){
+	local _browser_id
 	for _browser_id in "${BROWSER_LIST[@]}" ; do
 		[ -z "${BROWSER_NAME[${_browser_id}]}" ] && continue
 		echo "${BROWSER_NAME[${_browser_id}]}	:	${BROWSER_PATH[${_browser_id}]} ${BROWSER_ARGS[${_browser_id}]}"
 	done | awk '!a[$0]++' | awk 'BEGIN { RS="\n"; FS="	:	" } { print $1 "\t : " $2 }'| column -t -s $'\t'
+}
+
+list_browsers_table(){
+	local _browser_id
+	for _browser_id in "${BROWSER_LIST[@]}" ; do
+		[ -z "${BROWSER_NAME[${_browser_id}]}" ] && continue
+		echo "| - ${_browser_id}	| ${BROWSER_NAME[${_browser_id}]}	: ${BROWSER_PATH[${_browser_id}]}	| ${BROWSER_ARGS[${_browser_id}]:-}	|"
+	done | awk '!a[$0]++' | column -t -s $'\t'
 }
 
 ## firefox based browser
@@ -452,6 +461,13 @@ main(){
 		url_handler "https://duckduckgo.com/?q=$*"
 	fi
 }
+
+case "${@}" in
+	--ls-browsers|-lsb)
+		list_browsers_table
+		exit
+		;;
+esac
 
 if [ -z "$1" ]; then
 	open_a_browser;

--- a/nbrowser
+++ b/nbrowser
@@ -170,7 +170,7 @@ if ! has _copy_to_clipboard ;then
 fi
 
 open_a_browser(){
-	selected_browser=$(list_browsers | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "$((browser_count-1))")
+	selected_browser=$(list_browsers | rofi -dmenu -p 'nbrowser' -i -format "i s" -l "${#BROWSER_NAME[@]}")
 
 	[ -z "${selected_browser}" ] && exit 0
 
@@ -269,7 +269,7 @@ open_in_browser(){
 		COPY_TO_CLIPBOARD_OPTION=false
 	fi
 
-	selected_browser=$(list_browsers | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "$((browser_count-1))" )
+	selected_browser=$(list_browsers | rofi -dmenu -p 'Open URL with' -mesg "${@//&/&amp;}" -i -l "${#BROWSER_NAME[@]}" )
 
 	[ -z "${selected_browser}" ] && exit 0
 


### PR DESCRIPTION
related #28

this pr change the way browsers are stored, this will add a little complexity but also remove some limitation on the way we can manipulate the browser list.


### added
- `-lsb` option
	- print the browsers list in table format and exit, this is useful if user want to know the id of the browser they want to change it args. (need to be called from terminal)
	- ` | - browser_id | browser_name : browser_path | browser_args |`
	- ![image](https://github.com/MyOS-ArchLinux/nbrowser/assets/73726132/13b8c739-f421-46bc-8e4c-18424f59be4f)

- `add_browser()` function : easy way to add browsers
	- can be called with only one argument like `add_browser firefox` .
		- this will use this first argument as browser_id, and browser name ,get the path using `command -v firefox`
	- or can be called multiple arguments
		- `add_browser "browser_id" "browser_name" "browser_path" "browser_args"`
		- "browser_name", "browser_path", "browser_args" are optional 
- `rm_browser()` function : remove multiple browser from the browser list by using browser_id
